### PR TITLE
Fix Vercel 404 error by adding index.html and vercel.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>geminiai</title>
+</head>
+<body>
+    <h1>Welcome to geminiai</h1>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "builds": [
+        {
+            "src": "index.html",
+            "use": "@vercel/static"
+        }
+    ]
+}


### PR DESCRIPTION
This commit introduces a basic `index.html` file to serve as the main page and a `vercel.json` file to configure Vercel to use it. This should resolve the `404: NOT_FOUND` error.